### PR TITLE
Correcting hyperlinks to IPy notebooks for SciTools repo

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -13,10 +13,10 @@
      "source": [
       "## Iris Example Code Contents\n",
       "\n",
-      "* [Shapefile area averaging](http://nbviewer.ipython.org/urls/raw.github.com/dkillick/iris_example_code/master/area_weights.ipynb)\n",
-      "* [Cell comparisons](http://nbviewer.ipython.org/urls/raw.github.com/dkillick/iris_example_code/master/cell_comparison.ipynb)\n",
-      "* [Cell methods loading](http://nbviewer.ipython.org/urls/raw.github.com/dkillick/iris_example_code/master/cell_methods_loading.ipynb)\n",
-      "* [Coordinate categorisation](http://nbviewer.ipython.org/urls/raw.github.com/dkillick/iris_example_code/master/coord_categorisation.ipynb)"
+      "* [Shapefile area averaging](http://nbviewer.ipython.org/urls/raw.github.com/SciTools/iris_example_code/master/area_weights.ipynb)\n",
+      "* [Cell comparisons](http://nbviewer.ipython.org/urls/raw.github.com/SciTools/iris_example_code/master/cell_comparison.ipynb)\n",
+      "* [Cell methods loading](http://nbviewer.ipython.org/urls/raw.github.com/SciTools/iris_example_code/master/cell_methods_loading.ipynb)\n",
+      "* [Coordinate categorisation](http://nbviewer.ipython.org/urls/raw.github.com/SciTools/iris_example_code/master/coord_categorisation.ipynb)"
      ]
     }
    ],


### PR DESCRIPTION
Updating the hyperlinks for each IPython Notebook of example code to point at the raw GitHub page in SciTools/iris_example_code rather than dkillick/iris_example_code.
